### PR TITLE
Add requirements and usage docs for markdown conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,17 @@ Non-supporters of the Bogotá Metro project are predominantly renters (69%), lon
 
 
 # Unsupervised Cluster for all samples
+
+## Converting Markdown to DOCX
+The repository includes a script `scripts/convert_md_to_docx.py` that converts files in the `report` directory to DOCX format. Before running this script or the accompanying GitHub Actions workflow, install the Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Then you can manually run:
+
+```bash
+python scripts/convert_md_to_docx.py
+```
+

--- a/README.md
+++ b/README.md
@@ -144,4 +144,3 @@ Then you can manually run:
 ```bash
 python scripts/convert_md_to_docx.py
 ```
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-docx


### PR DESCRIPTION
## Summary
- list `python-docx` in new `requirements.txt`
- document how to install dependencies and run the markdown conversion script

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-docx)*
- `python scripts/convert_md_to_docx.py` *(fails: ModuleNotFoundError: No module named 'docx')*

------
https://chatgpt.com/codex/tasks/task_e_68868937402883279f983c8e0701964d